### PR TITLE
Check request is defined before using in feed timeout handler

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 # UNRELEASED
+- [FIXED] Check `request` is defined before using in feed timeout handler.
 - [FIXED] Update list of possible feed query parameters.
 
 # 0.14.0 (2017-09-29)

--- a/lib/feed.js
+++ b/lib/feed.js
@@ -547,7 +547,14 @@ Feed.prototype.on_timeout = function on_timeout() {
   var now = new Date();
   var elapsed_ms = now - self.pending.activity_at;
 
-  self.emit('timeout', {elapsed_ms: elapsed_ms, heartbeat: self.heartbeat, id: self.pending.request.id()});
+  var data = { elapsed_ms: elapsed_ms, heartbeat: self.heartbeat };
+  if (self.pending.request) {
+    data.id = self.pending.request.id();
+  } else {
+    self.log.debug('Timeout called for dead feed');
+  }
+
+  self.emit('timeout', data);
 
   /*
   var msg = ' for timeout after ' + elapsed_ms + 'ms; heartbeat=' + self.heartbeat;


### PR DESCRIPTION
Thanks for your hard work, please ensure all items are complete before opening.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://github.com/cloudant-labs/cloudant-follow/blob/master/DCO1.1.txt)
- [x] You have added tests for any code changes
- [x] You have updated the [CHANGES.md](https://github.com/cloudant-labs/cloudant-follow/blob/master/CHANGES.md)
- [x] You have completed the PR template below:

## What
Don't get `self.pending.request.id()` of dead feed on timeout.

## How
Check `self.pending.request` is defined before calling `.id()`.

## Issues
Fixes #14.
