### PR TITLE
Prepare version 0.17.0 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-# UNRELEASED
+# 0.17.0 (2018-03-22)
 - [NEW] Allow a custom HTTP agent to be specified.
 - [NEW] Trim the database URL if it includes the `/_changes` endpoint.
 - [FIXED] Correctly pass request parameters to `feed.filter` function.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudant-follow",
-  "version": "0.17.0-SNAPSHOT",
+  "version": "0.17.0",
   "author": {
     "name": "IBM Cloudant",
     "email": "support@cloudant.com"


### PR DESCRIPTION
# 0.17.0 (2018-03-22)
- [NEW] Allow a custom HTTP agent to be specified.
- [NEW] Trim the database URL if it includes the `/_changes` endpoint.
- [FIXED] Correctly pass request parameters to `feed.filter` function.
- [FIXED] Retry `/_db_updates` request using the last recorded sequence value as
  the `since` query parameter.
- [NOTE] Update engines in preparation for Node.js 4 “Argon” end-of-life.