### PR TITLE
Gk package lock

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,9 +56,9 @@ stage('Build') {
 
 stage('QA') {
   def axes = [
-    // Using CouchDB@1.7.1:
-    CouchDb1_7_1_Node:   { setupNodeAndTest('node', '1.7.1') },
-    // Using latest CouchDB@2.X:
+    // Using latest CouchDB @1.x:
+    CouchDb1LatestNode:   { setupNodeAndTest('node', '1') },
+    // Using latest CouchDB @2.X:
     CouchDb2LatestNode:   { setupNodeAndTest('node', '2') }
   ]
   parallel(axes) // Run the required axes in parallel

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -66,6 +66,7 @@ stage('QA') {
 
 // Publish the master branch
 stage('Publish') {
+  gkLockfile {}
   if (env.BRANCH_NAME == "master") {
     node {
       unstash 'built'


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description
Add `gkLockfile` call to `Jenkinsfile` for running `greenkeeper-lockfile` for automatic `package-lock` updates on greenkeeper branches.

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue

See Greenkeeper PRs.

### 2. What you expected to happen

`package-lock` file to get updated for dependency changes.

### 3. What actually happened

`package-lock` is not updated.

## Approach

Greenkeeper provides a `greenkeeper-lockfile` package to check for dependency changes and push an additional commit that updates the lockfile. The running of this package is in our global Jenkins shared library, this PR simply adds a stage to invoke that.

_Note_ the tagged shared library reference needs removing when the new global var has merged.

## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"

## Testing

- N/A build or packaging only changes

## Monitoring and Logging

- "No change"
