### PR TITLE
Pipe using decoded request.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # UNRELEASED
 - [NEW] Support use of changes selector filter.
 - [FIXED] Abort request retry for dead feed.
+- [FIXED] Pipe using decoded request.
 - [FIXED] Support using `since="now"` parameter in a `/_db_updates` feed.
 
 # 0.17.0 (2018-03-22)

--- a/lib/feed.js
+++ b/lib/feed.js
@@ -348,7 +348,7 @@ Feed.prototype.query = function query_feed() {
     changes_stream.log = lib.log4js.getLogger('stream ' + self.db);
     changes_stream.log.setLevel(self.log.level.levelStr);
     changes_stream.feed = self.feed;
-    resp.pipe(changes_stream);
+    feed_request.pipe(changes_stream);
 
     changes_stream.created_at = now;
     changes_stream.id = function() {


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes *
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

_* No changes to tests. CouchDB service used in tests doesn't support compressing of response bodies._

## Description
Automatic decoding of the response content is performed on the body data
returned through request (both through the request stream and passed to the
callback function) but is not performed on the response stream (available from
the response event) which is the unmodified `http.IncomingMessage` object which
may contain compressed data.
<!--
Provide a short description; saving the detail for the `Approach` section

Also EITHER:
Link to issue this PR is resolving, use the Fixes #nnn form so that the
issue closes automatically when the PR merges e.g.:

Fixes #23

OR

For PRs without an associated issue and/or test/build issues

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue
### 2. What you expected to happen
### 3. What actually happened
-->

## Approach
Pipe using decoded request object `feed_request`.
<!--
Be brief: which component(s) of the code base does the fix focus on.

A place to note whether the part of the code base that is being worked is
particularly sensitive.
-->

## Schema & API Changes
No change.
<!--
EITHER:

- "No change"

OR

For public API (as opposed to internal) changes

- "Fixing bug in API, will change x in such-and-such way"
-->

## Security and Privacy
No change.
<!--
EITHER:

- "No change"

OR

"Making changes in e.g. auth|https|encryption|io
need to be careful about..."

-->

## Testing
No change.
<!--
EITHER:

- Added new tests:
    - test x
    - test y
    - test z

OR

- Modified existing tests because ...

OR

- N/A build or packaging only changes

OR

In exceptional circumstances there may be a good reason we can't add automated
tests, for example if a specific device is required to reproduce a problem.

- No new tests because...
-->

## Monitoring and Logging
No change.
<!--
EITHER:

- "No change"

OR

- "Added new log line X..."
-->
