### PR TITLE
Updated version and changes for 0.18.1 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-# UNRELEASED
+# 0.18.1 (2019-01-22)
 - [FIXED] Multiple issues with `stop()` not actually stopping the feed.
 
 # 0.18.0 (2018-10-30)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudant-follow",
-  "version": "0.19.0-SNAPSHOT",
+  "version": "0.18.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudant-follow",
-  "version": "0.19.0-SNAPSHOT",
+  "version": "0.18.1",
   "author": {
     "name": "IBM Cloudant",
     "email": "support@cloudant.com"


### PR DESCRIPTION
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description

Proposed 0.18.1

## Approach

Updated `package.json`, `p[ackage-lock.json` and `CHANGES.md`

## Changes

# 0.18.1 (2019-01-23)
- [FIXED] Multiple issues with `stop()` not actually stopping the feed.
