### PR TITLE
Removed npm-cli-login dependency from publishing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- [FIXED] Removed inadvertent npm-cli-login dependency.
+
 # 0.18.1 (2019-01-22)
 - [FIXED] Multiple issues with `stop()` not actually stopping the feed.
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -96,7 +96,7 @@ stage('Publish') {
         // 4. publish the build to NPM adding a snapshot tag if pre-release
         sh """
           ${isReleaseVersion ? '' : ('npm version --no-git-tag-version ' + version + '.' + env.BUILD_ID)}
-          npm install npm-cli-login
+          npm install --no-save npm-cli-login
           ./node_modules/.bin/npm-cli-login
           npm publish ${isReleaseVersion ? '' : '--tag snapshot'}
         """


### PR DESCRIPTION
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description

Removed accidental `npm-cli-login` dependency introduced by publication automation.

## Approach

Added `--no-save` argument to `npm install`.

## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"

## Testing

- N/A build or packaging only changes

## Monitoring and Logging

- "No change"