### PR TITLE
Prepare for 0.18.2 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 0.18.2 (2019-06-17)
 
 - [FIXED] Removed inadvertent npm-cli-login dependency.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudant-follow",
-  "version": "0.18.2-SNAPSHOT",
+  "version": "0.18.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudant-follow",
-  "version": "0.18.2-SNAPSHOT",
+  "version": "0.18.2",
   "author": {
     "name": "IBM Cloudant",
     "email": "support@cloudant.com"


### PR DESCRIPTION
# 0.18.2 (2019-06-17)

- [FIXED] Removed inadvertent npm-cli-login dependency.